### PR TITLE
Update gradle

### DIFF
--- a/buildSrc/src/main/kotlin/lunabee-publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/lunabee-publish.gradle.kts
@@ -5,18 +5,9 @@ plugins {
     `maven-publish`
 }
 
-project.extensions.configure<JavaPluginExtension>("java") {
-    withJavadocJar()
-    withSourcesJar()
-}
-
 project.extensions.configure<PublishingExtension>("publishing") {
     setupMavenRepository()
     setupPublication()
-}
-
-tasks.named("publish${project.name.capitalized()}PublicationToMavenRepository") {
-    dependsOn(tasks.named("jar"))
 }
 
 /**
@@ -41,14 +32,11 @@ fun PublishingExtension.setupMavenRepository() {
  * Entry point for setting publication detail.
  */
 fun PublishingExtension.setupPublication() {
-    publications { setPublication() }
-}
-
-fun PublicationContainer.setPublication() {
-    this.create<MavenPublication>(project.name) {
-        setProjectDetails()
-        setJavaArtifacts(project)
-        setPom()
+    publications {
+        create<MavenPublication>(project.name) {
+            setProjectDetails()
+            setPom()
+        }
     }
 }
 
@@ -106,18 +94,4 @@ fun MavenPublication.setPom() {
             }
         }
     }
-}
-
-/**
- * Set additional artifacts to upload
- * - sources
- * - javadoc
- * - jar
- *
- * @param project project current project
- */
-fun MavenPublication.setJavaArtifacts(project: Project) {
-    artifact("${project.buildDir}/libs/${project.name}-${project.version}.jar")
-    artifact(project.tasks.named("sourcesJar"))
-    artifact(project.tasks.named("javadocJar"))
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Jun 27 10:12:59 CEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Update Gradle to 8.2.1 -> it breaks the Lunabee publish plugin, but it looks like there is a lot of useless stuff
- Clear `lunabee-publish.gradle.kts`
- Verify binary + source are uploaded
- Javadoc does not seem to be uploaded (it was already the case), but uploading the source seems to be enough to get the doc
<img width="2060" alt="image" src="https://github.com/LunabeeStudio/Double_Ratchet_KMM/assets/45555889/d7698ee4-9c41-4046-8c24-ab0019af564e">

