### PR TITLE
Use HKDF from BC

### DIFF
--- a/doubleratchet/src/jvmTest/kotlin/studio/lunabee/doubleratchet/BouncyCastleHKDFHashEngine.kt
+++ b/doubleratchet/src/jvmTest/kotlin/studio/lunabee/doubleratchet/BouncyCastleHKDFHashEngine.kt
@@ -1,0 +1,20 @@
+package studio.lunabee.doubleratchet
+
+import org.bouncycastle.crypto.digests.SHA512Digest
+import org.bouncycastle.crypto.generators.HKDFBytesGenerator
+import org.bouncycastle.crypto.params.HKDFParameters
+
+class BouncyCastleHKDFHashEngine {
+    private val hkdf = HKDFBytesGenerator(SHA512Digest())
+
+    fun deriveKey(key: ByteArray, salt: ByteArray, out: ByteArray = ByteArray(DERIVED_KEY_LENGTH_BYTE)): ByteArray {
+        val hkdfParams = HKDFParameters(key, salt, null)
+        hkdf.init(hkdfParams)
+        hkdf.generateBytes(out, 0, DERIVED_KEY_LENGTH_BYTE)
+        return out
+    }
+
+    companion object {
+        const val DERIVED_KEY_LENGTH_BYTE = 32
+    }
+}

--- a/doubleratchet/src/jvmTest/kotlin/studio/lunabee/doubleratchet/DoubleRatchetCryptoRepositoryImpl.kt
+++ b/doubleratchet/src/jvmTest/kotlin/studio/lunabee/doubleratchet/DoubleRatchetCryptoRepositoryImpl.kt
@@ -58,7 +58,7 @@ class DoubleRatchetCryptoRepositoryImpl : DoubleRatchetCryptoRepository {
     }
 
     private companion object {
-        val hashEngine = HashEngine()
+        val hashEngine = BouncyCastleHKDFHashEngine()
 
         val random = SecureRandom()
         const val DEFAULT_SALT_LENGTH_BYTE: Int = 32

--- a/doubleratchet/src/jvmTest/kotlin/studio/lunabee/doubleratchet/JcePBKDF2HashEngine.kt
+++ b/doubleratchet/src/jvmTest/kotlin/studio/lunabee/doubleratchet/JcePBKDF2HashEngine.kt
@@ -9,7 +9,7 @@ import javax.crypto.SecretKeyFactory
 import javax.crypto.spec.PBEKeySpec
 import javax.security.auth.DestroyFailedException
 
-class HashEngine {
+class JcePBKDF2HashEngine {
     private val secretKeyFactory: SecretKeyFactory
 
     init {


### PR DESCRIPTION
- Replace KDF PBKDF2 by HKDF (BC implementation)
- As the implementation is part of the client, it only change tests in this repo

<img width="626" alt="image" src="https://github.com/LunabeeStudio/Double_Ratchet_KMM/assets/45555889/92d1bb74-d83b-4f03-b9a4-09129e891d13">