### PR TITLE
add message key id to have the conversation id

### DIFF
--- a/doubleratchet/build.gradle.kts
+++ b/doubleratchet/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 
 group = "studio.lunabee.doubleratchet"
 description = "Kotlin multiplatform implementation of double ratchet algorithm"
-version = "0.1.3"
+version = "0.1.4"
 
 kotlin {
     jvm {

--- a/doubleratchet/src/commonMain/kotlin/studio/lunabee/doubleratchet/DoubleRatchetEngine.kt
+++ b/doubleratchet/src/commonMain/kotlin/studio/lunabee/doubleratchet/DoubleRatchetEngine.kt
@@ -21,6 +21,7 @@ import studio.lunabee.doubleratchet.model.AsymmetricKeyPair
 import studio.lunabee.doubleratchet.model.Conversation
 import studio.lunabee.doubleratchet.model.DRChainKey
 import studio.lunabee.doubleratchet.model.DRMessageKey
+import studio.lunabee.doubleratchet.model.DRMessageKeyId
 import studio.lunabee.doubleratchet.model.DRPublicKey
 import studio.lunabee.doubleratchet.model.DRRootKey
 import studio.lunabee.doubleratchet.model.DRSharedSecret
@@ -168,7 +169,7 @@ class DoubleRatchetEngine(
         messageHeader: MessageHeader,
         conversationId: DoubleRatchetUUID,
     ): DRMessageKey {
-        val messageKeyId = getMessageKeyId(conversationId, messageHeader.messageNumber)
+        val messageKeyId = DRMessageKeyId(conversationId, messageHeader.messageNumber)
         return doubleRatchetLocalDatasource.popMessageKey(messageKeyId)
             ?: throw DoubleRatchetError(DoubleRatchetError.Type.MessageKeyNotFound)
     }
@@ -198,7 +199,7 @@ class DoubleRatchetEngine(
 
             if (messageNumber != messageHeader.messageNumber) {
                 doubleRatchetLocalDatasource.saveMessageKey(
-                    id = getMessageKeyId(conversation.id, messageNumber),
+                    id = DRMessageKeyId(conversation.id, messageNumber),
                     key = messageKey,
                 )
             }
@@ -269,10 +270,6 @@ class DoubleRatchetEngine(
             this.nextMessageNumber = conversation.nextMessageNumber
             this.nextSequenceNumber = 0
         }
-    }
-
-    private fun getMessageKeyId(conversationId: DoubleRatchetUUID, messageNumber: Int): String {
-        return "${conversationId.uuidString()} - $messageNumber"
     }
 
     private suspend fun saveAndDestroy(conversation: Conversation) {

--- a/doubleratchet/src/commonMain/kotlin/studio/lunabee/doubleratchet/model/DRMessageKeyId.kt
+++ b/doubleratchet/src/commonMain/kotlin/studio/lunabee/doubleratchet/model/DRMessageKeyId.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023 Lunabee Studio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package studio.lunabee.doubleratchet.model
+
+import kotlin.jvm.JvmInline
+
+@JvmInline
+value class DRMessageKeyId private constructor(val value: String) {
+
+    internal constructor(
+        conversation: DoubleRatchetUUID,
+        messageNumber: Int,
+    ) : this("${conversation.uuidString()}$Separator$messageNumber")
+
+    val conversationId: String
+        get() = value.substringBefore(Separator)
+
+    private companion object {
+        private const val Separator: String = " - "
+    }
+}

--- a/doubleratchet/src/commonMain/kotlin/studio/lunabee/doubleratchet/storage/DoubleRatchetLocalDatasource.kt
+++ b/doubleratchet/src/commonMain/kotlin/studio/lunabee/doubleratchet/storage/DoubleRatchetLocalDatasource.kt
@@ -18,6 +18,7 @@ package studio.lunabee.doubleratchet.storage
 
 import studio.lunabee.doubleratchet.model.Conversation
 import studio.lunabee.doubleratchet.model.DRMessageKey
+import studio.lunabee.doubleratchet.model.DRMessageKeyId
 import studio.lunabee.doubleratchet.model.DoubleRatchetUUID
 
 /**
@@ -26,10 +27,10 @@ import studio.lunabee.doubleratchet.model.DoubleRatchetUUID
 interface DoubleRatchetLocalDatasource {
     suspend fun saveOrUpdateConversation(conversation: Conversation)
     suspend fun getConversation(id: DoubleRatchetUUID): Conversation?
-    suspend fun saveMessageKey(id: String, key: DRMessageKey)
+    suspend fun saveMessageKey(id: DRMessageKeyId, key: DRMessageKey)
 
     /**
      * Return and delete [DRMessageKey] with id [id]
      */
-    suspend fun popMessageKey(id: String): DRMessageKey?
+    suspend fun popMessageKey(id: DRMessageKeyId): DRMessageKey?
 }

--- a/doubleratchet/src/commonTest/kotlin/studio/lunabee/doubleratchet/PlainMapDoubleRatchetLocalDatasource.kt
+++ b/doubleratchet/src/commonTest/kotlin/studio/lunabee/doubleratchet/PlainMapDoubleRatchetLocalDatasource.kt
@@ -20,6 +20,7 @@ import studio.lunabee.doubleratchet.model.AsymmetricKeyPair
 import studio.lunabee.doubleratchet.model.Conversation
 import studio.lunabee.doubleratchet.model.DRChainKey
 import studio.lunabee.doubleratchet.model.DRMessageKey
+import studio.lunabee.doubleratchet.model.DRMessageKeyId
 import studio.lunabee.doubleratchet.model.DRPrivateKey
 import studio.lunabee.doubleratchet.model.DRPublicKey
 import studio.lunabee.doubleratchet.model.DRRootKey
@@ -82,12 +83,12 @@ class PlainMapDoubleRatchetLocalDatasource(
         null
     }
 
-    override suspend fun saveMessageKey(id: String, key: DRMessageKey) {
-        messageKeys[id] = DRMessageKey(key.value.copyOf())
+    override suspend fun saveMessageKey(id: DRMessageKeyId, key: DRMessageKey) {
+        messageKeys[id.value] = DRMessageKey(key.value.copyOf())
     }
 
-    override suspend fun popMessageKey(id: String): DRMessageKey? {
-        return messageKeys.remove(id)
+    override suspend fun popMessageKey(id: DRMessageKeyId): DRMessageKey? {
+        return messageKeys.remove(id.value)
     }
 
     override fun toString(): String {


### PR DESCRIPTION
## 📜 Description
Add value class DRMessageKeyId with create the stringID from the conversationID and the MessageNumber.
On AppSide, it allows us to get the conversation and decrypt/encrypt the messageKey before storing it

## 💡 Motivation and Context
## 💚 How did you test it?
Tests, Used in the app oneSafe
## 📝 Checklist

* [x] 📖 I reviewed the submitted code
* [x] 🛀 I launched `./gradlew detekt`
* [ ] 🏭 I implemented Unit Tests
